### PR TITLE
Add new apt signing key

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,10 @@
 ---
 - name: Configure the Oracle APT key
-  apt_key: url=https://www.virtualbox.org/download/oracle_vbox.asc
+  apt_key: url={{ item }}
            state=present
+  with_items:
+    - "https://www.virtualbox.org/download/oracle_vbox.asc"
+    - "https://www.virtualbox.org/download/oracle_vbox_2016.asc"
 
 - name: Configure the VirtualBox APT repositories
   apt_repository: repo="deb http://download.virtualbox.org/virtualbox/debian {{ ansible_distribution_release }} contrib"


### PR DESCRIPTION
# Overview

After Virtualbox 3.2, Oracle added an addition APT key for Virtualbox. This PR adds it to the list of Oracle APT keys that Ansible should install.

# Testing

See [hunchlab/azavea-hunchlab-web#1859](http://gitlab.internal.azavea.com/hunchlab/azavea-hunchlab-web/merge_requests/1859)